### PR TITLE
passing arguments to wollok interpreter

### DIFF
--- a/runPrograms.sh
+++ b/runPrograms.sh
@@ -16,13 +16,14 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Compilando archivos Wollok..."
-interpret "*.wlk" $CLI_DIR
+
+interpret "*.wlk" $CLI_DIR "$@"
 if [ $? -ne 0 ] ; then
     exit 1
 fi
 echo "==========================================================="
 echo "Ejecutando programas..."
-interpretSingle "*.wpgm" $CLI_DIR
+interpretSingle "*.wpgm" $CLI_DIR "$@"
 if [ $? -ne 0 ] ; then
     echo
     echo "$RED$BOLD""ERROR en el programa ejecutado. $RESET$RED""Revise el log para más información.$RESET"


### PR DESCRIPTION
Cuando se ejecutaba un programa que usaba una librería externa no funcionaba porque no se estaban enviando los parámetros al intérprete de wollok al ejecutar un programa