### PR TITLE
add log4j config

### DIFF
--- a/winterpreter.sh
+++ b/winterpreter.sh
@@ -15,4 +15,8 @@ else
     CLASSPATH="$WOLLOK_DEPENDENCIES:$OTHER_DEPENDENCIES"
 fi
 
-java -cp "$CLASSPATH" org.uqbar.project.wollok.launch.WollokLauncher $@
+LOG4J_CONFIG=$(find  -name log4j.properties -print -quit)
+if [ ! -z  "$LOG4J_CONFIG" ] ; then
+  LOG4J_CONFIG="-Dlog4j.configuration='file:${LOG4J_CONFIG}'"
+fi
+eval java -cp "$CLASSPATH" "$LOG4J_CONFIG" org.uqbar.project.wollok.launch.WollokLauncher $@


### PR DESCRIPTION
Los proyectos wollok suelen traer un log4j.properties que estaban siendo ignorados al ejecutarse desde wollok-cli. Este PR busca un log4j.properties dentro de la carpeta o alguna subcarpeta con los wlk, wpmg o wtest que se quieren ejecutar y se pasa como parametro de la JVM. 
Si no encuentra ningun log4j.properties, no configura nada.
Si hay más de uno, usa el primero que encuentra. Esto podría ser algo a mejorar a futuro. Puede pasar si se quiere ejecutar más de un proyecto a la vez. 