### PR TITLE
Switch to using `grep -E`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $CLI_DIR/includes/commons.sh
 source $CLI_DIR/includes/colors.sh
 
-find . -name "*.wlk" | egrep '.*' -q
+find . -name "*.wlk" | grep -E '.*' -q
 
 if [ $? -eq 0 ]; then
     echo "Validando archivos Wollok..."

--- a/runPrograms.sh
+++ b/runPrograms.sh
@@ -9,7 +9,7 @@ CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $CLI_DIR/includes/commons.sh
 source $CLI_DIR/includes/colors.sh
 
-find . -name "*.wpgm" ! -path "*/bin/**" ! -path "*/wsanity-check-examples/*" | egrep '.*' -q
+find . -name "*.wpgm" ! -path "*/bin/**" ! -path "*/wsanity-check-examples/*" | grep -E '.*' -q
 if [ $? -ne 0 ]; then
     echo "$RED$BOLD""ERROR: no se encontraron archivos con extensión *.wpgm.$RESET"
     exit 1

--- a/runTests.sh
+++ b/runTests.sh
@@ -10,13 +10,13 @@ CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $CLI_DIR/includes/commons.sh
 source $CLI_DIR/includes/colors.sh
 
-find . -name "*.wtest" ! -path "*/bin/**" ! -path "*/wsanity-check-examples/*" | egrep '.*' -q
+find . -name "*.wtest" ! -path "*/bin/**" ! -path "*/wsanity-check-examples/*" | grep -E '.*' -q
 if [ $? -ne 0 ]; then
     echo "$RED$BOLD""ERROR: no se encontraron archivos con extensión *.wtest.$RESET"
     exit 1
 fi
 
-find . -name "*.wlk" | egrep '.*'
+find . -name "*.wlk" | grep -E '.*'
 
 if [ $? -eq 0 ]; then
     echo "Validando archivos Wollok..."

--- a/util/addTravisInAllProjects.sh
+++ b/util/addTravisInAllProjects.sh
@@ -9,7 +9,7 @@ function addTravisFile() {
     #     return
     # fi
 
-    find . -name "*.wtest" -type f | egrep '.*'
+    find . -name "*.wtest" -type f | grep -E '.*'
     if [ $? -eq 0 ]; then
         echo "   Creating Travis file for tests"
         cp ./travisTests.yml ./$1/.travis.yml
@@ -22,7 +22,7 @@ function addTravisFile() {
 function addBadgeInReadme() {
     README_file="./$1/README.md"
     TRAVIS_BADGE="[![Build_Status](https://travis-ci.org/wollok/$1.svg?branch=master)](https://travis-ci.org/wollok/$1)"
-    
+
     if [ -s $README_file ]; then
         grep travis-ci $README_file -q
         if [ $? -eq 0 ]; then
@@ -45,5 +45,5 @@ function addBadgeInReadme() {
 for i in `find . -mindepth 1 -maxdepth 1 -type d -not -path "./.history*" | sed "s/\.\///g"`
     do
         addTravisFile $i
-        # addBadgeInReadme $i 
+        # addBadgeInReadme $i
     done


### PR DESCRIPTION
`egrep` has been deprecated, changing to `grep -E` is recommended to avoid warnings or errors in the future.